### PR TITLE
Add builder to build list of items

### DIFF
--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/ItemBuilder.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/ItemBuilder.kt
@@ -83,6 +83,11 @@ class ItemBuilder {
         value?.let { item[this] = AttributeValue.builder().bs(value.map { SdkBytes.fromInputStream(it) }).build() }
     }
 
+
+    infix fun String.fromList(block: ItemListBuilder.() -> Unit) {
+        item[this] = AttributeValue.builder().l(ItemListBuilder().apply(block).build()).build()
+    }
+
     fun build(): Map<String, AttributeValue> = item
 
 }

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/ItemListBuilder.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/ItemListBuilder.kt
@@ -1,0 +1,16 @@
+package com.ximedes.dynamodb.dsl.builders
+
+import com.ximedes.dynamodb.dsl.DynamoDbDSL
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+@DynamoDbDSL
+class ItemListBuilder {
+    private val items = mutableListOf<AttributeValue>()
+
+    fun item(init: ItemBuilder.() -> Unit) {
+        val map = AttributeValue.builder().m(ItemBuilder().apply(init).build()).build()
+        items.add(map)
+    }
+
+    fun build() = items.toList()
+}

--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/ItemBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/ItemBuilderTest.kt
@@ -19,6 +19,7 @@ package com.ximedes.dynamodb.dsl.builders
 
 import com.ximedes.dynamodb.dsl.Item
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import software.amazon.awssdk.core.SdkBytes
@@ -52,6 +53,16 @@ internal class ItemBuilderTest {
             "list_of_inputStreams" from listOfByteArrays.map { ByteArrayInputStream(it) }
             "item" from {
                 "string" from "b"
+            }
+            "items" fromList {
+                item {
+                    "string" from "a"
+                    "int" from 1
+                }
+                item {
+                    "string" from "b"
+                    "int" from 2
+                }
             }
         }
 
@@ -96,6 +107,15 @@ internal class ItemBuilderTest {
                     assertEquals(
                             AttributeValue.builder().m(mapOf("string" to AttributeValue.builder().s("b").build())).build(),
                             dslItem["item"]
+                    )
+                },
+                {
+                    assertEquals(
+                            AttributeValue.builder().l(listOf(
+                                AttributeValue.builder().m(mapOf("string" to AttributeValue.builder().s("a").build(), "int" to AttributeValue.builder().n("1").build())).build(),
+                                AttributeValue.builder().m(mapOf("string" to AttributeValue.builder().s("b").build(), "int" to AttributeValue.builder().n("2").build())).build()
+                            )).build(),
+                            dslItem["items"]
                     )
                 }
         )


### PR DESCRIPTION
I'm currently working on an application that needs to store an list of items:

```json
{
  "pk": "uuid",
  "sk": "$timestamp",
  "items": [{ "title": "Hi", "id": "uuid-1" }, { "title": "Test", "id": "uuid-2" }]
}
```
To support this functionality i would like to propose the following DSL:
```kotlin
client.putItem("tableName") {
  item {
    "pk" from "uuid"
    "sk" from "$timestamp"
    "items" fromList {
       item {
         "title" from "Hi"
         "id" from "uuid-1"
       }
       item {
         "title" from "Test"
         "id" from "uuid-2"
       }
    }
  }
}
```
