### PR TITLE
Support UpdateTable requests

### DIFF
--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateGlobalSecondaryIndexActionBuilder.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateGlobalSecondaryIndexActionBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,14 @@
 package com.ximedes.dynamodb.dsl.builders
 
 import com.ximedes.dynamodb.dsl.DynamoDbDSL
-import software.amazon.awssdk.services.dynamodb.model.*
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput
+import software.amazon.awssdk.services.dynamodb.model.UpdateGlobalSecondaryIndexAction
 
 @DynamoDbDSL
-class GlobalSecondaryIndexBuilder(name: String) {
-    private val _builder = GlobalSecondaryIndex.builder().indexName(name)
-    private val keySchemaElements = mutableListOf<KeySchemaElement>()
+class UpdateGlobalSecondaryIndexActionBuilder(name: String) {
+    private val _builder = UpdateGlobalSecondaryIndexAction.builder().indexName(name)
     private var provisionedThroughput: ProvisionedThroughput? = null
 
-
-    fun partitionKey(name: String) {
-        keySchemaElements.add(KeySchemaElement.builder().attributeName(name).keyType(KeyType.HASH).build())
-    }
-
-    fun sortKey(name: String) {
-        keySchemaElements.add(KeySchemaElement.builder().attributeName(name).keyType(KeyType.RANGE).build())
-    }
 
     fun provisionedThroughput(readCapacityUnits: Long, writeCapacityUnits: Long) {
         provisionedThroughput = ProvisionedThroughput.builder()
@@ -42,15 +34,7 @@ class GlobalSecondaryIndexBuilder(name: String) {
                 .build()
     }
 
-    fun projection(type: ProjectionType, block: (ProjectionBuilder.() -> Unit) = {}) {
-        val projection = ProjectionBuilder(type).apply(block).build()
-        _builder.projection(projection)
-    }
-
-
-    fun build(parentThroughput: ProvisionedThroughput? = null): GlobalSecondaryIndex {
-        _builder.keySchema(*keySchemaElements.toTypedArray())
-
+    fun build(parentThroughput: ProvisionedThroughput? = null): UpdateGlobalSecondaryIndexAction {
         (provisionedThroughput ?: parentThroughput)?.let {
             _builder.provisionedThroughput(it)
         }

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateTableRequestBuilder.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateTableRequestBuilder.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ximedes.dynamodb.dsl.builders
+
+import com.ximedes.dynamodb.dsl.DynamoDbDSL
+import software.amazon.awssdk.services.dynamodb.model.*
+
+@DynamoDbDSL
+class UpdateTableRequestBuilder(tableName: String) {
+    private var _builder = UpdateTableRequest.builder().tableName(tableName)
+    private val globalSecondaryIndexUpdates = mutableListOf<GlobalSecondaryIndexUpdate>()
+    private var provisionedThroughput: ProvisionedThroughput? = null
+
+    fun attributes(init: AttributeDefinitionsBuilder.() -> Unit) {
+        _builder.attributeDefinitions(AttributeDefinitionsBuilder().apply(init).build())
+    }
+
+    fun billingMode(mode: BillingMode) {
+        _builder.billingMode(mode)
+    }
+
+    fun provisionedThroughput(readCapacityUnits: Long, writeCapacityUnits: Long) {
+        provisionedThroughput = ProvisionedThroughput.builder()
+                .readCapacityUnits(readCapacityUnits)
+                .writeCapacityUnits(writeCapacityUnits)
+                .build()
+    }
+
+    fun createGlobalSecondaryIndex(name: String, create: GlobalSecondaryIndexBuilder.() -> Unit) {
+        val index = GlobalSecondaryIndexBuilder(name).apply(create).build()
+
+        globalSecondaryIndexUpdates.add(GlobalSecondaryIndexUpdate.builder().create(
+            CreateGlobalSecondaryIndexAction.builder()
+                .indexName(name)
+                .keySchema(index.keySchema())
+                .projection(index.projection())
+                .provisionedThroughput(index.provisionedThroughput())
+                .build()
+        ).build())
+    }
+
+    fun updateGlobalSecondaryIndex(name: String, update: UpdateGlobalSecondaryIndexActionBuilder.() -> Unit) {
+        globalSecondaryIndexUpdates.add(GlobalSecondaryIndexUpdate.builder().update(
+            UpdateGlobalSecondaryIndexActionBuilder(name).apply(update).build()
+        ).build())
+    }
+
+    fun deleteGlobalSecondaryIndex(name: String) {
+        globalSecondaryIndexUpdates.add(GlobalSecondaryIndexUpdate.builder().delete(
+            DeleteGlobalSecondaryIndexAction.builder().indexName(name).build()
+        ).build())
+    }
+
+    fun build(): UpdateTableRequest {
+        provisionedThroughput?.let {
+            _builder.billingMode(BillingMode.PROVISIONED).provisionedThroughput(it)
+        }
+
+        if (globalSecondaryIndexUpdates.isNotEmpty()) {
+            _builder.globalSecondaryIndexUpdates(*globalSecondaryIndexUpdates.toTypedArray())
+        }
+
+        return _builder.build()
+    }
+
+}

--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateTableRequestBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateTableRequestBuilderTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ximedes.dynamodb.dsl.builders
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.dynamodb.model.*
+
+internal class UpdateTableRequestBuilderTest {
+
+    private fun updateTableRequest(tableName: String = "foo", init: UpdateTableRequestBuilder.() -> Unit): UpdateTableRequest {
+        return UpdateTableRequestBuilder(tableName).apply(init).build()
+    }
+
+    @Test
+    fun `tableName matches`() {
+        val sdkRequest = UpdateTableRequest.builder()
+                .tableName("foo")
+                .build()
+
+        val dslRequest = updateTableRequest("foo") {}
+
+        assertEquals(sdkRequest.tableName(), dslRequest.tableName())
+    }
+
+    @Test
+    fun `default billing mode is unspecified`() {
+        assertNull(updateTableRequest("foo") {}.billingMode())
+    }
+
+    @Test
+    fun `billing mode can be changed`() {
+        val dslRequest = updateTableRequest("foo") {
+            billingMode(BillingMode.PAY_PER_REQUEST)
+        }
+        assertEquals(BillingMode.PAY_PER_REQUEST, dslRequest.billingMode())
+    }
+
+    @Test
+    fun `attribute definitions match`() {
+        val sdkRequest = CreateTableRequest.builder()
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName("s1").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("s2").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("n1").attributeType(ScalarAttributeType.N).build(),
+                        AttributeDefinition.builder().attributeName("b1").attributeType(ScalarAttributeType.B).build()
+                ).build()
+
+        val dslRequest = updateTableRequest {
+            attributes {
+                string("s1", "s2")
+                number("n1")
+                binary("b1")
+            }
+        }
+
+        assertEquals(sdkRequest.attributeDefinitions(), dslRequest.attributeDefinitions())
+    }
+
+    @Test
+    fun `provisioned throughput`() {
+        val sdkRequest = CreateTableRequest.builder()
+                .provisionedThroughput(
+                        ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build()
+                )
+                .build()
+
+        val dslRequest = updateTableRequest {
+            provisionedThroughput(1L, 2L)
+        }
+
+        assertEquals(BillingMode.PROVISIONED, dslRequest.billingMode())
+        assertEquals(sdkRequest.provisionedThroughput(), dslRequest.provisionedThroughput())
+    }
+
+    @Test
+    fun `global secondary index`() {
+        val sdkRequest = UpdateTableRequest.builder()
+            .globalSecondaryIndexUpdates(
+                GlobalSecondaryIndexUpdate.builder().create(
+                    CreateGlobalSecondaryIndexAction.builder()
+                        .indexName("gsi1")
+                        .keySchema(
+                            KeySchemaElement.builder().keyType(KeyType.HASH).attributeName("pk").build(),
+                            KeySchemaElement.builder().keyType(KeyType.RANGE).attributeName("sk").build()
+                        )
+                        .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+                        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build())
+                        .build()
+                ).build(),
+                GlobalSecondaryIndexUpdate.builder().update(
+                    UpdateGlobalSecondaryIndexAction.builder()
+                        .indexName("gsi2")
+                        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build())
+                        .build()
+                ).build(),
+                GlobalSecondaryIndexUpdate.builder().delete(
+                    DeleteGlobalSecondaryIndexAction.builder()
+                        .indexName("gsi3")
+                        .build()
+                ).build()
+            )
+            .build()
+
+        val dslRequest = updateTableRequest {
+            createGlobalSecondaryIndex("gsi1") {
+                partitionKey("pk")
+                sortKey("sk")
+                projection(ProjectionType.ALL)
+                provisionedThroughput(1L, 2L)
+            }
+            updateGlobalSecondaryIndex("gsi2") {
+                provisionedThroughput(1L, 2L)
+            }
+            deleteGlobalSecondaryIndex("gsi3")
+        }
+
+        assertEquals(sdkRequest.globalSecondaryIndexUpdates(), dslRequest.globalSecondaryIndexUpdates())
+    }
+
+    @Test
+    fun `full UpdateTable test`() {
+        val sdkRequest = UpdateTableRequest.builder()
+            .attributeDefinitions(
+                AttributeDefinition.builder().attributeName("s1").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("s2").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("n1").attributeType(ScalarAttributeType.N).build(),
+                AttributeDefinition.builder().attributeName("b1").attributeType(ScalarAttributeType.B).build()
+            )
+            .provisionedThroughput(
+                ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build()
+            )
+            .globalSecondaryIndexUpdates(
+                GlobalSecondaryIndexUpdate.builder().create(
+                    CreateGlobalSecondaryIndexAction.builder()
+                        .indexName("gsi1")
+                        .keySchema(
+                            KeySchemaElement.builder().keyType(KeyType.HASH).attributeName("pk").build(),
+                            KeySchemaElement.builder().keyType(KeyType.RANGE).attributeName("sk").build()
+                        )
+                        .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+                        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build())
+                        .build()
+                ).build(),
+                GlobalSecondaryIndexUpdate.builder().update(
+                    UpdateGlobalSecondaryIndexAction.builder()
+                        .indexName("gsi2")
+                        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build())
+                        .build()
+                ).build(),
+                GlobalSecondaryIndexUpdate.builder().delete(
+                    DeleteGlobalSecondaryIndexAction.builder()
+                        .indexName("gsi3")
+                        .build()
+                ).build()
+            )
+            .build()
+
+        val dslRequest = updateTableRequest {
+            attributes {
+                string("s1", "s2")
+                number("n1")
+                binary("b1")
+            }
+            billingMode(BillingMode.PAY_PER_REQUEST)
+            provisionedThroughput(1L, 2L)  // overrides the pay-per-request billing mode
+            createGlobalSecondaryIndex("gsi1") {
+                partitionKey("pk")
+                sortKey("sk")
+                projection(ProjectionType.ALL)
+                provisionedThroughput(1L, 2L)
+            }
+            updateGlobalSecondaryIndex("gsi2") {
+                provisionedThroughput(1L, 2L)
+            }
+            deleteGlobalSecondaryIndex("gsi3")
+        }
+
+        assertEquals(sdkRequest.globalSecondaryIndexUpdates(), dslRequest.globalSecondaryIndexUpdates())
+    }
+}


### PR DESCRIPTION
Not all UpdateTable changes are included yet. This PR adds support for
* Attribute definitions
* Billing mode
* Provisioned throughput
* Global secondary index updates (create/update/delete)

See https://docs.aws.amazon.com/cli/latest/reference/dynamodb/update-table.html for details.