### PR TITLE
Fix async requests to log exceptions correctly

### DIFF
--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/BatchGetItem.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/BatchGetItem.kt
@@ -18,7 +18,6 @@
 package com.ximedes.dynamodb.dsl
 
 import com.ximedes.dynamodb.dsl.builders.BatchGetItemRequestBuilder
-import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse
@@ -28,5 +27,5 @@ fun DynamoDbClient.batchGetItem(init: BatchGetItemRequestBuilder.() -> Unit): Ba
 }
 
 suspend fun DynamoDbAsyncClient.batchGetItem(init: BatchGetItemRequestBuilder.() -> Unit): BatchGetItemResponse {
-    return BatchGetItemRequestBuilder().apply(init).build().logAndRun(::batchGetItem).await()
+    return BatchGetItemRequestBuilder().apply(init).build().logAndRunAsync(::batchGetItem)
 }

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/BatchWriteItem.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/BatchWriteItem.kt
@@ -18,7 +18,6 @@
 package com.ximedes.dynamodb.dsl
 
 import com.ximedes.dynamodb.dsl.builders.BatchWriteItemRequestBuilder
-import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
@@ -28,5 +27,5 @@ fun DynamoDbClient.batchWriteItem(init: BatchWriteItemRequestBuilder.() -> Unit)
 }
 
 suspend fun DynamoDbAsyncClient.batchWriteItem(init: BatchWriteItemRequestBuilder.() -> Unit): BatchWriteItemResponse {
-    return BatchWriteItemRequestBuilder().apply(init).build().logAndRun(::batchWriteItem).await()
+    return BatchWriteItemRequestBuilder().apply(init).build().logAndRunAsync(::batchWriteItem)
 }

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/CreateTable.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/CreateTable.kt
@@ -18,7 +18,6 @@
 package com.ximedes.dynamodb.dsl
 
 import com.ximedes.dynamodb.dsl.builders.CreateTableRequestBuilder
-import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.CreateTableResponse
@@ -30,7 +29,7 @@ fun DynamoDbClient.createTable(table: String, init: CreateTableRequestBuilder.()
 suspend fun DynamoDbAsyncClient.createTable(
     table: String, init: CreateTableRequestBuilder.() -> Unit
 ): CreateTableResponse {
-    return CreateTableRequestBuilder(table).apply(init).build().logAndRun(::createTable).await()
+    return CreateTableRequestBuilder(table).apply(init).build().logAndRunAsync(::createTable)
 }
 
 

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/DeleteItem.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/DeleteItem.kt
@@ -18,7 +18,6 @@
 package com.ximedes.dynamodb.dsl
 
 import com.ximedes.dynamodb.dsl.builders.DeleteItemRequestBuilder
-import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse
@@ -30,5 +29,5 @@ fun DynamoDbClient.deleteItem(table: String, block: DeleteItemRequestBuilder.() 
 suspend fun DynamoDbAsyncClient.deleteItem(
     table: String, block: DeleteItemRequestBuilder.() -> Unit
 ): DeleteItemResponse {
-    return DeleteItemRequestBuilder(table).apply(block).build().logAndRun(::deleteItem).await()
+    return DeleteItemRequestBuilder(table).apply(block).build().logAndRunAsync(::deleteItem)
 }

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/DeleteTable.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/DeleteTable.kt
@@ -18,7 +18,6 @@
 package com.ximedes.dynamodb.dsl
 
 import com.ximedes.dynamodb.dsl.builders.DeleteTableRequestBuilder
-import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableResponse
@@ -32,7 +31,7 @@ fun DynamoDbClient.deleteTable(
 suspend fun DynamoDbAsyncClient.deleteTable(
     table: String, init: DeleteTableRequestBuilder.() -> Unit = {}
 ): DeleteTableResponse {
-    return DeleteTableRequestBuilder(table).apply(init).build().logAndRun(::deleteTable).await()
+    return DeleteTableRequestBuilder(table).apply(init).build().logAndRunAsync(::deleteTable)
 }
 
 

--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/PutItem.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/PutItem.kt
@@ -18,7 +18,6 @@
 package com.ximedes.dynamodb.dsl
 
 import com.ximedes.dynamodb.dsl.builders.PutItemRequestBuilder
-import kotlinx.coroutines.future.await
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.PutItemResponse
@@ -34,7 +33,7 @@ fun DynamoDbClient.putItem(
 }
 
 suspend fun DynamoDbAsyncClient.putItem(tableName: String, block: PutItemRequestBuilder.() -> Unit): PutItemResponse {
-    return PutItemRequestBuilder(tableName).apply(block).build().logAndRun(::putItem).await()
+    return PutItemRequestBuilder(tableName).apply(block).build().logAndRunAsync(::putItem)
 }
 
 suspend fun DynamoDbAsyncClient.putItem(


### PR DESCRIPTION
## Summary
- ensure async DynamoDB helpers use `logAndRunAsync`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*