### PR TITLE
Fix class name in DeleteTableRequestBuilderTest

### DIFF
--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteTableRequestBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteTableRequestBuilderTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest
 
-internal class DeleteTableRequestBuilderTestm {
+internal class DeleteTableRequestBuilderTest {
 
     @Test
     fun nameMatches() {


### PR DESCRIPTION
## Summary
- correct typo in DeleteTableRequestBuilderTest class name

## Testing
- `mvn -q test` *(fails: mvn command not found)*