### PR TITLE
Fix duplicate GitHub URL in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <scm>
         <connection>scm:git:git://github.com/ximedes/kotlin-dynamodb-wrapper.git</connection>
         <developerConnection>scm:git:ssh://github.com/Ximedes/kotlin-dynamodb-wrapper.git</developerConnection>
-        <url>https://github.com/github.com/ximedes/kotlin-dynamodb-wrapper/tree/master</url>
+        <url>https://github.com/ximedes/kotlin-dynamodb-wrapper/tree/master</url>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary
- correct SCM URL in pom.xml so there is no repeated `github.com`

## Testing
- `apache-maven-3.9.9/bin/mvn -q validate` *(fails: plugin resolution requires network)*