### PR TITLE
Update TODO comment in BatchGetItemRequestBuilderTest

### DIFF
--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/BatchGetItemRequestBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/BatchGetItemRequestBuilderTest.kt
@@ -53,7 +53,7 @@ internal class BatchGetItemRequestBuilderTest {
         ).build()
         val dslRequest = dslRequest {
             items("table1") {
-                // TODO this API sucks
+                // TODO: simplify key specification API
                 keys({ "a" from "b" },
                         { "c" from "d" })
             }


### PR DESCRIPTION
## Summary
- clarify the TODO comment in `BatchGetItemRequestBuilderTest.kt`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*