### PR TITLE
Add returnValues option to DeleteItemRequestBuilder

### DIFF
--- a/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteItemRequestBuilder.kt
+++ b/src/main/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteItemRequestBuilder.kt
@@ -21,6 +21,7 @@ import com.ximedes.dynamodb.dsl.DynamoDbDSL
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnItemCollectionMetrics
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue
 
 @DynamoDbDSL
 class DeleteItemRequestBuilder(tableName: String) {
@@ -51,6 +52,10 @@ class DeleteItemRequestBuilder(tableName: String) {
 
     fun returnItemCollectionMetrics(returnItemCollectionMetrics: ReturnItemCollectionMetrics) {
         _builder.returnItemCollectionMetrics(returnItemCollectionMetrics)
+    }
+
+    fun returnValues(returnValue: ReturnValue) {
+        _builder.returnValues(returnValue)
     }
 
 }

--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteItemRequestBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteItemRequestBuilderTest.kt
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnItemCollectionMetrics
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue
 
 internal class DeleteItemRequestBuilderTest {
     private fun dslRequest(tableName: String = "foo", init: DeleteItemRequestBuilder.() -> Unit) =
@@ -96,6 +97,18 @@ internal class DeleteItemRequestBuilderTest {
             attributeNames("a" to "z")
         }
         assertEquals(sdkRequest.expressionAttributeNames(), dslRequest.expressionAttributeNames())
+    }
+
+    @Test
+    fun returnValues() {
+        val sdkRequest = DeleteItemRequest.builder()
+            .returnValues(ReturnValue.ALL_OLD)
+            .build()
+        val dslRequest = dslRequest {
+            returnValues(ReturnValue.ALL_OLD)
+        }
+        assertEquals(sdkRequest.returnValues(), dslRequest.returnValues())
+        assertEquals(ReturnValue.ALL_OLD, dslRequest.returnValues())
     }
 
 


### PR DESCRIPTION
## Summary
- expose `returnValues` on DeleteItemRequestBuilder
- add test for returnValues support

## Testing
- `mvn -q test` *(fails: could not resolve kotlin-maven-plugin)*