### PR TITLE
Fix mismatched SDK objects in builder tests

### DIFF
--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/DeleteBuilderTest.kt
@@ -76,7 +76,7 @@ internal class DeleteBuilderTest {
     @Test
     fun returnValuesOnConditionCheckFailure() {
         val sdkDelete =
-                Put.builder().returnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD).build()
+                Delete.builder().returnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD).build()
         val dslDelete = dslDelete {
             returnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD)
         }

--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateBuilderTest.kt
@@ -40,7 +40,7 @@ internal class UpdateBuilderTest {
 
     @Test
     fun key() {
-        val sdkUpdate = Get.builder().key(
+        val sdkUpdate = Update.builder().key(
                 mapOf(
                         "a" to AttributeValue.builder().n("1").build(),
                         "b" to AttributeValue.builder().s("a").build()

--- a/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateTableRequestBuilderTest.kt
+++ b/src/test/kotlin/com/ximedes/dynamodb/dsl/builders/UpdateTableRequestBuilderTest.kt
@@ -54,7 +54,7 @@ internal class UpdateTableRequestBuilderTest {
 
     @Test
     fun `attribute definitions match`() {
-        val sdkRequest = CreateTableRequest.builder()
+        val sdkRequest = UpdateTableRequest.builder()
                 .attributeDefinitions(
                         AttributeDefinition.builder().attributeName("s1").attributeType(ScalarAttributeType.S).build(),
                         AttributeDefinition.builder().attributeName("s2").attributeType(ScalarAttributeType.S).build(),
@@ -75,7 +75,7 @@ internal class UpdateTableRequestBuilderTest {
 
     @Test
     fun `provisioned throughput`() {
-        val sdkRequest = CreateTableRequest.builder()
+        val sdkRequest = UpdateTableRequest.builder()
                 .provisionedThroughput(
                         ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(2L).build()
                 )


### PR DESCRIPTION
## Summary
- ensure DeleteBuilder tests use Delete.builder
- ensure UpdateBuilder tests use Update.builder
- ensure UpdateTableRequestBuilder tests use UpdateTableRequest.builder

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*